### PR TITLE
Add travis job to trigger image rebuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+script:
+  - curl --data build=true -X POST https://registry.hub.docker.com/u/whynothugo/makepkg/trigger/$HUB_TOKEN/


### PR DESCRIPTION
Docker images can quickly go stale. This adds a travis job that triggers rebuilds.

By having travis run this job cron'd every day, we make sure the Docker Hub image is frequently updated.