### PR TITLE
Support installing AUR dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 docker-makepkg
 ==============
 
-This docker image is intended to tests `PKGBUILDs`, by running `makepkg -sf` in
-a clean Arch installation.
-It is intended to be used by packagers, both via CI, and on non-ArchLinux
-environments.
+This docker image is intended to tests `PKGBUILDs`, by installing dependencies
+and running `makepkg -f` in a clean Arch installation. It is intended to be
+used by packagers, both via CI, and on non-ArchLinux environments.
 
 Usage with travis
 -----------------
@@ -38,12 +37,10 @@ Extra details
 -------------
 
 * `base-devel` is preinstalled.
-* All `depends` will be installed.
+* All `depends` will be installed (including AUR packages using [yay](https://github.com/Jguer/yay)).
 * GPG keys used to verify signatures are auto-fetched.
 
 Licence
 -------
 
 This repository is licensed under the ISC licence. See LICENCE for details.
-
-

--- a/run.sh
+++ b/run.sh
@@ -2,12 +2,12 @@
 
 # Make a copy so we never alter the original
 cp -r /pkg /tmp/pkg
+cd /tmp/pkg
 
-# Make sure we can RW the copy
-chown -R notroot /tmp/pkg
-chmod -R u+rw /tmp/pkg
-find /tmp/pkg -type d -exec chmod u+x {} \;
+# Install (official repo + AUR) dependencies using yay. We avoid using makepkg
+# -s since it is unable to install AUR dependencies.
+yay -S --noconfirm \
+    $(pacman --deptest $(source ./PKGBUILD && echo ${depends[@]} ${makedepends[@]}))
 
 # Do the actual building
-cd /tmp/pkg
-sudo -u notroot makepkg -fs --noconfirm
+makepkg -f

--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@ cd /tmp/pkg
 
 # Install (official repo + AUR) dependencies using yay. We avoid using makepkg
 # -s since it is unable to install AUR dependencies.
-yay -S --noconfirm \
+yay -Sy --noconfirm \
     $(pacman --deptest $(source ./PKGBUILD && echo ${depends[@]} ${makedepends[@]}))
 
 # Do the actual building


### PR DESCRIPTION
This handles installation of declared dependencies and make dependencies by using the [`yay` pacman wrapper](https://github.com/Jguer/yay) to install missing dependencies.

It installs `python-srcinfo` and `jq` to parse the `depends` and `makedepends` list without trying to parse the PKGBUILD shell script.

Fixes #4