### PR TITLE
Use -e to exit on any run.sh command failure

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 # Make a copy so we never alter the original
 cp -r /pkg /tmp/pkg
 cd /tmp/pkg


### PR DESCRIPTION
Fail early (for example non-existent dependencies) 