### PR TITLE
point to tag for base package instead of deprecated package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM archlinux/base
+FROM archlinux:base-devel
 
 COPY run.sh /run.sh
 


### PR DESCRIPTION
The [`archlinux/base`](https://hub.docker.com/r/archlinux/base) package is marked as deprecated:

>  This image is deprecated. Please see the new image at [https://hub.docker.com/r/archlinux/archlinux](https://hub.docker.com/r/archlinux/archlinux)

This new package has tags for `base` and `base-devel` outlined in [the README](https://gitlab.archlinux.org/archlinux/archlinux-docker), so I've pointed this Dockerfile at the tag and it seems to build fine without other changes.

Without this change `docker build .` fails due to missing glibc symbols during the `git` installation:

```
...
#8 127.2 Optional dependencies for git
#8 127.2     tk: gitk and git gui
#8 127.2     perl-libwww: git svn
#8 127.2     perl-term-readkey: git svn and interactive.singlekey setting
#8 127.2     perl-mime-tools: git send-email
#8 127.2     perl-net-smtp-ssl: git send-email TLS support
#8 127.2     perl-authen-sasl: git send-email TLS support
#8 127.2     perl-mediawiki-api: git mediawiki support
#8 127.2     perl-datetime-format-iso8601: git mediawiki support
#8 127.2     perl-lwp-protocol-https: git mediawiki https support
#8 127.2     perl-cgi: gitweb (web interface) support
#8 127.2     python: git svn & git p4
#8 127.2     subversion: git svn
#8 127.2     org.freedesktop.secrets: keyring credential helper
#8 127.2     libsecret: libsecret credential helper [installed]
#8 127.2 :: Running post-transaction hooks...
#8 127.2 (1/7) Creating system user accounts...
#8 127.3 Creating group git with gid 977.
#8 127.3 Creating user git (git daemon user) with uid 977 and gid 977.
#8 127.3 (2/7) Reloading system manager configuration...
#8 127.3   Skipped: Current root is not booted.
#8 127.3 (3/7) Creating temporary files...
#8 127.3 /usr/lib/tmpfiles.d/journal-nocow.conf:26: Failed to resolve specifier: uninitialized /etc detected, skipping
#8 127.3 All rules containing unresolvable specifiers will be skipped.
#8 127.3 (4/7) Arming ConditionNeedsUpdate...
#8 127.3 (5/7) Warn about old perl modules
#8 127.3 (6/7) Cleaning up package cache...
#8 127.3 (7/7) Updating the info directory file...
#8 127.9 pacman: /usr/lib/libc.so.6: version `GLIBC_2.33' not found (required by pacman)
#8 127.9 pacman: /usr/lib/libc.so.6: version `GLIBC_2.33' not found (required by /usr/lib/libalpm.so.12)
```