### PR TITLE
Install checkdepends

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN mkdir .gnupg && \
     echo "keyserver-options auto-key-retrieve" > .gnupg/gpg.conf
 
 # Install yay (for building AUR dependencies):
+# hadolint ignore=DL3003
 RUN git clone https://aur.archlinux.org/yay-bin.git && \
     cd yay-bin && \
     makepkg --noconfirm --syncdeps --rmdeps --install --clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ RUN git clone https://aur.archlinux.org/yay-bin.git && \
 
 # Build the package
 WORKDIR /pkg
-CMD /bin/sh /run.sh
+CMD ["/bin/bash", "/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/run.sh
+++ b/run.sh
@@ -8,10 +8,10 @@ cd /tmp/pkg
 
 # Install (official repo + AUR) dependencies using yay. We avoid using makepkg
 # -s since it is unable to install AUR dependencies.
-depends=(); makedepends=()
+depends=(); makedepends=(); checkdepends=()
 # shellcheck disable=1091
 . ./PKGBUILD
-deps=( "${depends[@]}" "${makedepends[@]}" )
+deps=( "${depends[@]}" "${makedepends[@]}" "${checkdepends[@]}" )
 pacman --deptest "${deps[@]}" | xargs yay -Sy --noconfirm
 
 # Do the actual building

--- a/run.sh
+++ b/run.sh
@@ -8,14 +8,17 @@ cd /tmp/pkg
 
 # Install (official repo + AUR) dependencies using yay. We avoid using makepkg
 # -s since it is unable to install AUR dependencies.
-yay -Sy --noconfirm \
-    $(pacman --deptest $(source ./PKGBUILD && echo ${depends[@]} ${makedepends[@]}))
+depends=(); makedepends=()
+# shellcheck disable=1091
+. ./PKGBUILD
+deps=( "${depends[@]}" "${makedepends[@]}" )
+pacman --deptest "${deps[@]}" | xargs yay -Sy --noconfirm
 
 # Do the actual building
 makepkg -f
 
 # Store the built package(s). Ensure permissions match the original PKGBUILD.
 if [ -n "$EXPORT_PKG" ]; then
-    sudo chown $(stat -c '%u:%g' /pkg/PKGBUILD) ./*pkg.tar*
+    sudo chown "$(stat -c '%u:%g' /pkg/PKGBUILD)" ./*pkg.tar*
     sudo mv ./*pkg.tar* /pkg
 fi


### PR DESCRIPTION
Hey :wave:

Looked for a Docker image to use for testing the packages I maintain and found this, which was great. However, this image do not install dependencies listed in `checkdepends`, which is a problem for my use-case.

While this is a one-line change, I got a bit carried away and fixed (or inline ignored) the warnings from [shellcheck](https://github.com/koalaman/shellcheck) and [hadolint](https://github.com/hadolint/hadolint). If you find these changes too intrusive I could definitely rework this PR and just and `checkdepends` to the old one-liner.