### PR TITLE
Add SYNC_DATABASE option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Extra details
 
 * `base-devel` is preinstalled.
 * All `depends` will be installed (including AUR packages using [paru](https://github.com/Jguer/paru)).
+* You may pass `SYNC_DATABASE=1` to force a `pacman -Sy` to refresh the
+  database, since it updates quite frequently.
 * GPG keys used to verify signatures are auto-fetched.
 
 Licence

--- a/run.sh
+++ b/run.sh
@@ -6,6 +6,11 @@ set -e
 cp -r /pkg /tmp/pkg
 cd /tmp/pkg
 
+# Sync database
+if [ -n "$SYNC_DATABASE" ]; then
+    paru -S --refresh
+fi
+
 # Do the actual building. Paru will fetch all dependencies for us (including
 # AUR dependencies) and then build the package.
 paru -U --noconfirm


### PR DESCRIPTION
As noted in https://github.com/WhyNotHugo/docker-makepkg/issues/23, the database goes out of sync quite fast, this adds a `SYNC_DATABASE` option to run `paru -S --refresh` to update the database before doing the build